### PR TITLE
Updating webapi port to 5001 for all OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,5 +66,5 @@ Follow the instructions on [docker installation guide](./docs/docker-compose/REA
 2|`forms-flow-forms`|form.io form building. This must be started earlier for resource role id's creation|`http://localhost:3001`|`admin@example.com/changeme`
 3|`forms-flow-analytics`|Redash analytics server, This must be started earlier for redash key creation|`http://localhost:7001`|Use the credentials used for registration / [Default user credentials](./docs/forms-flow-ai-properties.md)
 4|`forms-flow-web`|formsflow Landing web app|`http://localhost:3000`|[Default user credentials](./docs/forms-flow-ai-properties.md)
-5|`forms-flow-api`|API services|`http://localhost:5000`|`Authorization tocken from keycloak role based user credentials`
+5|`forms-flow-api`|API services|`http://localhost:5001`|`Authorization tocken from keycloak role based user credentials`
 6|`forms-flow-bpm`|Camunda integration|`http://localhost:8000/camunda`| [Default user credentials](./docs/forms-flow-ai-properties.md) 

--- a/docker-compose/configuration/conf.d/nginx.conf
+++ b/docker-compose/configuration/conf.d/nginx.conf
@@ -33,7 +33,7 @@ http {
             sub_filter ="/ ="/api/;
             sub_filter_once off;
 
-            proxy_pass          http://forms-flow-webapi:5000;
+            proxy_pass          http://forms-flow-webapi:5001;
             proxy_redirect      off;
         }
         location ^~ /forms/ {

--- a/docker-compose/configuration/config.js
+++ b/docker-compose/configuration/config.js
@@ -1,15 +1,15 @@
 window["_env_"] = {
-NODE_ENV: "production",
-REACT_APP_API_SERVER_URL:"http://{your-ip-address}:3001",
-REACT_APP_API_PROJECT_URL:"http://{your-ip-address}:3001",
-REACT_APP_KEYCLOAK_CLIENT:"forms-flow-web",
-REACT_APP_KEYCLOAK_URL_REALM:"{realm-name}",
-REACT_APP_KEYCLOAK_URL:"http://{your-ip-address}:8080",
-REACT_APP_WEB_BASE_URL:"http://{your-ip-address}:5000",
-REACT_APP_BPM_URL:"http://{your-ip-address}:8000/camunda",
-REACT_APP_WEBSOCKET_ENCRYPT_KEY:"giert989jkwrgb@DR55",
-REACT_APP_APPLICATION_NAME:"formsflow.ai",
-REACT_APP_WEB_BASE_CUSTOM_URL:"",
-REACT_APP_FORMIO_JWT_SECRET:"--- change me now ---",
-REACT_APP_USER_ACCESS_PERMISSIONS:{accessAllowApplications:false, accessAllowSubmissions:false}
+    NODE_ENV: "production",
+    REACT_APP_API_SERVER_URL: "http://{your-ip-address}:3001",
+    REACT_APP_API_PROJECT_URL: "http://{your-ip-address}:3001",
+    REACT_APP_KEYCLOAK_CLIENT: "forms-flow-web",
+    REACT_APP_KEYCLOAK_URL_REALM: "{realm-name}",
+    REACT_APP_KEYCLOAK_URL: "http://{your-ip-address}:8080",
+    REACT_APP_WEB_BASE_URL: "http://{your-ip-address}:5001",
+    REACT_APP_BPM_URL: "http://{your-ip-address}:8000/camunda",
+    REACT_APP_WEBSOCKET_ENCRYPT_KEY: "giert989jkwrgb@DR55",
+    REACT_APP_APPLICATION_NAME: "formsflow.ai",
+    REACT_APP_WEB_BASE_CUSTOM_URL: "",
+    REACT_APP_FORMIO_JWT_SECRET: "--- change me now ---",
+    REACT_APP_USER_ACCESS_PERMISSIONS: { accessAllowApplications: false, accessAllowSubmissions: false }
 };

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -185,7 +185,7 @@ services:
       CUSTOM_SUBMISSION_ENABLED: ${CUSTOM_SUBMISSION_ENABLED}
       FORMIO_JWT_SECRET: ${FORMIO_JWT_SECRET:---- change me now ---}
     ports:
-      - "5000:5000"
+      - "5001:5000"
     networks:
       - formsflow
 

--- a/docker-compose/sample.env
+++ b/docker-compose/sample.env
@@ -119,7 +119,7 @@ USER_ACCESS_PERMISSIONS={"accessAllowApplications":false,"accessAllowSubmissions
 ##Camunda Rest API URI
 BPM_API_URL=http://{your-ip-address}:8000/camunda
 ##web Api End point
-FORMSFLOW_API_URL=http://{your-ip-address}:5000
+FORMSFLOW_API_URL=http://{your-ip-address}:5001
 ##web API CORS origins
 #FORMSFLOW_API_CORS_ORIGINS=*
 #Sentiment analysis url

--- a/docs/docker-compose/README.md
+++ b/docs/docker-compose/README.md
@@ -47,7 +47,7 @@ In this document, you will see the basic details to install and run the applicat
 * Analytics should be up and available for use at port defaulted to 7001 i.e. http://localhost:7001/
 * Business Process Engine should be up and available for use at port defaulted to 8000 i.e. http://localhost:8000/camunda/
 * FormIO should be up and available for use at port defaulted to 3001 i.e. http://localhost:3001/
-* formsflow.ai Rest API should be up and available for use at port defaulted to 5000 i.e. http://localhost:5001/checkpoint
+* formsflow.ai Rest API should be up and available for use at port defaulted to 5001 i.e. http://localhost:5001/checkpoint
 * formsflow.ai web application should be up and available for use at port defaulted to 3000 i.e. http://localhost:3000/
 
 

--- a/docs/docker-compose/README.md
+++ b/docs/docker-compose/README.md
@@ -47,7 +47,7 @@ In this document, you will see the basic details to install and run the applicat
 * Analytics should be up and available for use at port defaulted to 7001 i.e. http://localhost:7001/
 * Business Process Engine should be up and available for use at port defaulted to 8000 i.e. http://localhost:8000/camunda/
 * FormIO should be up and available for use at port defaulted to 3001 i.e. http://localhost:3001/
-* formsflow.ai Rest API should be up and available for use at port defaulted to 5000 i.e. http://localhost:5000/checkpoint
+* formsflow.ai Rest API should be up and available for use at port defaulted to 5000 i.e. http://localhost:5001/checkpoint
 * formsflow.ai web application should be up and available for use at port defaulted to 3000 i.e. http://localhost:3000/
 
 

--- a/docs/forms-flow-ai-properties.md
+++ b/docs/forms-flow-ai-properties.md
@@ -17,7 +17,7 @@ Variable name (Docker-compose) | Variable name (Docker) | Descreption | Default 
 `CAMUNDA_POSTGRES_USER`| |Postgres Database Username used on installation to create the database|`admin`
 `CAMUNDA_POSTGRES_PASSWORD`| |Postgres Database Password used on installation to create the database|`changeme`
 `CAMUNDA_JDBC_DB_NAME`| |Postgres Database Name used on installation to create the database|`formsflow-bpm`
-`FORMSFLOW_API_URL`:triangular_flag_on_post:|`REACT_APP_WEB_BASE_URL`|formsflow.ai Rest API URI|`http://{your-ip-address}:5000`
+`FORMSFLOW_API_URL`:triangular_flag_on_post:|`REACT_APP_WEB_BASE_URL`|formsflow.ai Rest API URI|`http://{your-ip-address}:5001`
 `FORMIO_DEFAULT_PROJECT_URL`:triangular_flag_on_post:|` FORMIO_URL`|The URL of the forms-flow-forms server|`http://{your-ip-address}:3001`
 `FORMIO_ROOT_EMAIL`|`ROOT_EMAIL `|forms-flow-forms admin login|`admin@example.com`
 `FORMIO_ROOT_PASSWORD`|`ROOT_PASSWORD `|forms-flow-forms admin password|`changeme`

--- a/docs/helm/sample.env
+++ b/docs/helm/sample.env
@@ -104,7 +104,7 @@ USER_ACCESS_PERMISSIONS={"accessAllowApplications":false,"accessAllowSubmissions
 ##Camunda Rest API URI
 BPM_API_URL=http://{your-ip-address}:8000/camunda
 ##web Api End point
-FORMSFLOW_API_URL=http://{your-ip-address}:5000
+FORMSFLOW_API_URL=http://{your-ip-address}:5001
 ##web API CORS origins
 #FORMSFLOW_API_CORS_ORIGINS=*
 

--- a/scripts/install.bash
+++ b/scripts/install.bash
@@ -1,9 +1,9 @@
 #!/bin/bash
 ipadd=$(hostname -I | awk '{print $1}')
-webapi_port=5000
+webapi_port=5001
 if [ "$(uname)" == "Darwin" ]; then
     ipadd=$(ipconfig getifaddr en0)
-    webapi_port=5001
+    # webapi_port=5001
 fi
 
 docker_compose_file='docker-compose.yml'

--- a/scripts/install.bat
+++ b/scripts/install.bat
@@ -115,7 +115,7 @@ EXIT /B %ERRORLEVEL%
    set REACT_APP_KEYCLOAK_CLIENT="forms-flow-web",
    set REACT_APP_KEYCLOAK_URL_REALM="forms-flow-ai",
    set REACT_APP_KEYCLOAK_URL="http://%ip-add%:8080",
-   set REACT_APP_WEB_BASE_URL="http://%ip-add%:5000",
+   set REACT_APP_WEB_BASE_URL="http://%ip-add%:5001",
    set REACT_APP_BPM_URL="http://%ip-add%:8000/camunda",
    set REACT_APP_WEBSOCKET_ENCRYPT_KEY="giert989jkwrgb@DR55",
    set REACT_APP_APPLICATION_NAME="formsflow.ai",
@@ -155,7 +155,7 @@ EXIT /B %ERRORLEVEL%
 :forms-flow-bpm
 
     SETLOCAL
-    set FORMSFLOW_API_URL=http://%ip-add%:5000
+    set FORMSFLOW_API_URL=http://%ip-add%:5001
     set WEBSOCKET_SECURITY_ORIGIN=http://%ip-add%:3000
     set SESSION_COOKIE_SECURE=false
 


### PR DESCRIPTION
Updating web api port to 5001, as 5000 is reserved in some OS (Mac). Rather than creating different docker-compose and nginx file, thought would be better to update for all.